### PR TITLE
fix(ui): remove ghost dot artifact from wave rings during animation d…

### DIFF
--- a/src/app/[locale]/globals.css
+++ b/src/app/[locale]/globals.css
@@ -156,6 +156,9 @@ body {
   0% {
     width: 64px;
     height: 64px;
+    opacity: 0;
+  }
+  10% {
     opacity: 0.7;
   }
   100% {
@@ -167,6 +170,7 @@ body {
 
 .animate-wave {
   animation: wave 1.5s infinite;
+  animation-fill-mode: backwards;
 }
 
 /* Prevent iOS zoom on input focus */


### PR DESCRIPTION
…elay

The wave ring divs had no initial size, so the border-4 rendered as a tiny dot before each ring's animationDelay fired. Fixed by starting opacity at 0 and using animation-fill-mode: backwards so rings remain invisible during their delay period.